### PR TITLE
fix(eip6780): Storage slot 0 be increased one more time

### DIFF
--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -690,7 +690,7 @@ class TransactionTransitionToolConverter(CamelModel):
 class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConverter):
     """Generic object that can represent all Ethereum transaction types."""
 
-    gas_limit: HexNumber = Field(HexNumber(21_000), serialization_alias="gas")
+    gas_limit: HexNumber = Field(HexNumber(1_000_000), serialization_alias="gas")
     to: Address | None = Field(Address(0xAA))
     data: Bytes = Field(Bytes(b""), alias="input")
 

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -34,7 +34,7 @@ def pytest_addoption(parser):
         action="store",
         dest="default_gas_price",
         type=int,
-        default=10**9,
+        default=2*10**9,
         help=("Default gas price used for transactions, unless overridden by the test."),
     )
     execute_group.addoption(

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -788,6 +788,13 @@ def test_selfdestruct_pre_existing(
             balance=balance,
             storage={0: call_times},
         )
+        # If the selfdestruct_contract_initial_balance > 0, means that the contract was called one 
+        # more time, so the storage slot 0 should be more than 1
+        if selfdestruct_contract_initial_balance > 0:
+            post[selfdestruct_contract_address] = Account(
+                balance=balance,
+                storage={0: call_times + 1},
+            )
     else:
         post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
 


### PR DESCRIPTION
```
============================================================= test session starts ==============================================================
platform darwin -- Python 3.13.1, pytest-7.4.4, pluggy-1.5.0 -- /Users/son.ho/Backend/ronin-execution-spec-tests/.venv/bin/python
Generating fixtures for: Cancun
Only generating fixtures with stable/deployed forks: Specify an upcoming fork via --until=fork to add forks under development.
solc: 0.8.24
Start seed for EOA: 0xaf83d2077ff7e87fc12a8f0e5e10003e17313b130f84ae008a2ea682c54a6a40
cachedir: .pytest_cache
metadata: {'Python': '3.13.1', 'Platform': 'macOS-14.7.2-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '7.4.4', 'pluggy': '1.5.0'}, 'Plugins': {'html': '4.1.1', 'json-report': '1.5.0', 'metadata': '3.1.1', 'cov': '4.1.0', 'custom-report': '1.0.1', 'xdist': '3.6.1', 'typeguard': '4.3.0'}, 'Command-line args': '<code>fill -c pytest-execute.ini --fork=Cancun --rpc-endpoint=http://34.30.122.240:8545 --rpc-seed-key 0x7ca3c559a80bd88737050131609b57b88725b5aa3616b6561febedbc8a1fa8d1 --rpc-chain-id 2020 tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing -s -v</code>', 'Tools': {'solc': '0.8.24'}, 'Senders': {}}
rootdir: /Users/son.ho/Backend/ronin-execution-spec-tests
configfile: pytest-execute.ini
plugins: html-4.1.1, json-report-1.5.0, metadata-3.1.1, cov-4.1.0, custom-report-1.0.1, xdist-3.6.1, typeguard-4.3.0
collected 9 items / 1 deselected / 8 selected

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-single_call] Starting EOA index: 0xaf83d2077ff7e87fc12a8f0e5e10003e17313b130f84ae008a2ea682c54a6a40
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 122180
PASSEDUsed balance=0.000369696000100000

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-single_call_self] Deploying contract with gas limit: 113534
PASSEDUsed balance=0.000303658000100000

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_single_sendall_recipient] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 122180

PASSEDUsed balance=0.000407395000100001

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_single_self_recipient] Deploying contract with gas limit: 113534
PASSEDUsed balance=0.000361328000100001

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_sendall_recipients] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 132410
PASSEDUsed balance=0.000601141000100003

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_sendall_recipients_including_self] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 132410
PASSEDUsed balance=0.000542033000100003

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_sendall_recipients_including_self_last] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 132410
PASSEDUsed balance=0.000542033000100003

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_repeating_sendall_recipients_including_self] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 132410
PASSEDUsed balance=0.000675529000100015

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_repeating_sendall_recipients_including_self_last] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 132410
PASSEDUsed balance=0.000675529000100015


=============================================================== warnings summary ===============================================================
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-single_call]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-single_call_self]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_single_sendall_recipient]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_single_self_recipient]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_sendall_recipients]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_sendall_recipients_including_self]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_sendall_recipients_including_self_last]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_repeating_sendall_recipients_including_self]
tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_multiple_repeating_sendall_recipients_including_self_last]
  /opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/copy.py:152: DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.
    rv = reductor(4)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 9 passed, 1 deselected, 9 warnings in 689.11s (0:11:29) ============================================
```