### PR TITLE
fix(tests): EIP-7623: add sidecar for blob tx

### DIFF
--- a/tests/prague/eip7623_increase_calldata_cost/conftest.py
+++ b/tests/prague/eip7623_increase_calldata_cost/conftest.py
@@ -20,8 +20,8 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools import Opcodes as Op
 
-from ...cancun.eip4844_blobs.spec import Spec as EIP_4844_Spec
 from .helpers import DataTestType, find_floor_cost_threshold
+from .spec import Spec
 
 
 @pytest.fixture
@@ -101,7 +101,7 @@ def blob_versioned_hashes(ty: int) -> Sequence[Hash] | None:
     return (
         add_kzg_version(
             [Hash(1)],
-            EIP_4844_Spec.BLOB_COMMITMENT_VERSION_KZG,
+            1,
         )
         if ty == 3
         else None
@@ -321,7 +321,7 @@ def tx(
     tx_error: TransactionException | None,
 ) -> Transaction:
     """Create the transaction used in each test."""
-    return Transaction(
+    tx = Transaction(
         ty=ty,
         sender=sender,
         data=tx_data,
@@ -333,3 +333,12 @@ def tx(
         blob_versioned_hashes=blob_versioned_hashes,
         error=tx_error,
     )
+
+    if tx.ty == 3:
+        tx.blobs = [bytes(4096 * 32)]
+        tx.blob_kzg_commitments = [Spec.INF_POINT]
+        tx.blob_kzg_proofs = [Spec.INF_POINT]
+        tx.blob_versioned_hashes = [Spec.kzg_to_versioned_hash(Spec.INF_POINT)]
+        tx.wrapped_blob_transaction = True
+
+    return tx

--- a/tests/prague/eip7623_increase_calldata_cost/spec.py
+++ b/tests/prague/eip7623_increase_calldata_cost/spec.py
@@ -1,6 +1,10 @@
 """Defines EIP-7623 specification constants and functions."""
 
 from dataclasses import dataclass
+from hashlib import sha256
+from typing import Optional
+
+from ethereum_test_tools import Transaction
 
 
 @dataclass(frozen=True)
@@ -24,3 +28,41 @@ class Spec:
 
     STANDARD_TOKEN_COST = 4
     TOTAL_COST_FLOOR_PER_TOKEN = 10
+
+    BLOB_TX_TYPE = 0x03
+    FIELD_ELEMENTS_PER_BLOB = 4096
+    BLS_MODULUS = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
+    BLOB_COMMITMENT_VERSION_KZG = 1
+    POINT_EVALUATION_PRECOMPILE_ADDRESS = 10
+    POINT_EVALUATION_PRECOMPILE_GAS = 50_000
+    # MAX_VERSIONED_HASHES_LIST_SIZE = 2**24
+    # MAX_CALLDATA_SIZE = 2**24
+    # MAX_ACCESS_LIST_SIZE = 2**24
+    # MAX_ACCESS_LIST_STORAGE_KEYS = 2**24
+    # MAX_TX_WRAP_COMMITMENTS = 2**12
+    # LIMIT_BLOBS_PER_TX = 2**12
+    HASH_OPCODE_BYTE = 0x49
+    HASH_GAS_COST = 3
+    INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
+
+    @classmethod
+    def kzg_to_versioned_hash(
+        cls,
+        kzg_commitment: bytes | int,  # 48 bytes
+        blob_commitment_version_kzg: Optional[bytes | int] = None,
+    ) -> bytes:
+        """Calculate versioned hash for a given KZG commitment."""
+        if blob_commitment_version_kzg is None:
+            blob_commitment_version_kzg = cls.BLOB_COMMITMENT_VERSION_KZG
+        if isinstance(kzg_commitment, int):
+            kzg_commitment = kzg_commitment.to_bytes(48, "big")
+        if isinstance(blob_commitment_version_kzg, int):
+            blob_commitment_version_kzg = blob_commitment_version_kzg.to_bytes(1, "big")
+        return blob_commitment_version_kzg + sha256(kzg_commitment).digest()[1:]
+
+    @classmethod
+    def get_total_blob_gas(cls, *, tx: Transaction, blob_gas_per_blob: int) -> int:
+        """Calculate the total blob gas for a transaction."""
+        if tx.blob_versioned_hashes is None:
+            return 0
+        return blob_gas_per_blob * len(tx.blob_versioned_hashes)

--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -17,7 +17,6 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools import Opcodes as Op
 
-from ...cancun.eip4844_blobs.spec import Spec as EIP_4844_Spec
 from .helpers import DataTestType
 from .spec import ref_spec_7623
 
@@ -194,14 +193,14 @@ def test_transaction_validity_type_1_type_2(
         pytest.param(
             add_kzg_version(
                 [Hash(x) for x in range(1)],
-                EIP_4844_Spec.BLOB_COMMITMENT_VERSION_KZG,
+                1,
             ),
             id="single_blob",
         ),
         pytest.param(
             add_kzg_version(
                 [Hash(x) for x in range(6)],
-                EIP_4844_Spec.BLOB_COMMITMENT_VERSION_KZG,
+                1,
             ),
             id="multiple_blobs",
         ),


### PR DESCRIPTION
## 🗒️ Description
Some tests EIP-7623 use blob tx can't be run in `execute` mode, this PR calculates sidecars for blob tx for EIP-7623 tests to adapt to `execute` mode.

## 🚀 Result
```
========= 387 passed, 387 warnings in 440.78s (0:07:20) ========
```
