### PR TITLE
fix(tests): EIP-3860: increase intrinsic gas

### DIFF
--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -224,7 +224,7 @@ class TestContractCreationGasUsage:
         On EIP-7623, we need to use an access list to raise the intrinsic gas cost to
         be above the floor data cost.
         """
-        return [AccessList(address=Address(i), storage_keys=[]) for i in range(1, 478)]
+        return [AccessList(address=Address(i), storage_keys=[]) for i in range(1, 642)]
 
     @pytest.fixture
     def exact_intrinsic_gas(


### PR DESCRIPTION
## 🗒️ Description

Some tests have intrinsic gas lower than floor gas, which leads to ERROR. This PR increases number of addresses in access list to ensure intrinsic gas is above floor gas.
