### PR TITLE
ci: use public runner for fixtures release

### DIFF
--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -20,7 +20,6 @@ jobs:
           echo "features=$(grep -Po "^[0-9a-zA-Z_\-]+" ./.github/configs/feature.yaml | jq -R . | jq -cs .)" >> "$GITHUB_OUTPUT"
   build:
     needs: features
-    runs-on: self-hosted
     strategy:
       matrix:
         name: ${{ fromJson(needs.features.outputs.features) }}

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -23,7 +23,6 @@ jobs:
           echo names=${names}
           echo names=${names} >> "$GITHUB_OUTPUT"
   build:
-    runs-on: self-hosted
     needs: feature-names
     strategy:
       matrix:


### PR DESCRIPTION
## 🗒️ Description
[use public runner for fixtures release](https://github.com/ronin-chain/execution-spec-tests/commit/bd40a7d8bd200e4413cba37de1ae02760b4cb6f8)

