### PR TITLE
fix(tests): EIP-2935: use Op.NUMBER instead of hard-coded block number 1

### DIFF
--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -240,7 +240,7 @@ def test_block_hashes_call_opcodes(
     )
 
     code = (
-        Op.MSTORE(0, 1)
+        Op.MSTORE(0, Op.SUB(Op.NUMBER(), 1))
         + Op.SSTORE(
             return_code_slot,
             call_opcode(


### PR DESCRIPTION
## 🗒️ Description

When running test `test_block_hashes_call_opcodes` in execute mode, it always calls the history contract to get block hash of block number 1, which is invalid in a live network. So I modified contract code to call the latest finalized block instead of hard-coded block number 1.
