### PR TITLE
fix(execute): execute mode skips tests that contain blob tx

### DIFF
--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -395,3 +395,9 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
             )
         elif "test_many_delegations" in item.name:
             item.add_marker(pytest.mark.skip(reason="This test needs high gas"))
+
+        # Skip tests that execute mode not supported
+        if "type_3" in item.name:
+            item.add_marker(
+                pytest.mark.skip(reason="Transaction type 3 is not supported in execute mode")
+            )


### PR DESCRIPTION
## 🗒️ Description

Currently, execute mode not supported blob tx. So, just skip all tests that contain blob txs in execute mode. 